### PR TITLE
Don't crash in IE <= 8 during initialization

### DIFF
--- a/jquery.detect_swipe.js
+++ b/jquery.detect_swipe.js
@@ -55,7 +55,7 @@
   }
 
   function setup() {
-    this.addEventListener('touchstart', onTouchStart, false);
+    this.addEventListener && this.addEventListener('touchstart', onTouchStart, false);
   }
 
   function teardown() {


### PR DESCRIPTION
addEventListener doesn't exist in IE8. Since we don't care about touch there, just check to see if it exists first.
