### PR TITLE
Add bower json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+    "name": "jquery-detect-swipe",
+    "version": "2.1.1",
+    "description": "Gives easy access to left/right/up/down swipe events for iOS and other touch devices.",
+    "homepage": "https://github.com/marcandre/detect_swipe",
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:marcandre/detect_swipe.git"
+    },
+    "authors": [
+        "Marc-André Lafortune"
+    ],
+    "license": "MIT",
+    "readmeFilename": "README.md",
+    "main": "jquery.detect_swipe.js",
+    "dependencies": {
+        "jquery": ">= 1.3.1"
+    },
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "test",
+        "tests"
+    ]
+}


### PR DESCRIPTION
I've added a bower.json file, so detect_swipe can be installed with bower:
````bower install git@github.com:marcandre/detect_swipe.git````

You could register it with bower so it could be installed by calling:
````bower install jquery-detect-swipe````

What do you think?