### PR TITLE
Add ignoreMultiTouch option

### DIFF
--- a/jquery.detect_swipe.js
+++ b/jquery.detect_swipe.js
@@ -10,7 +10,8 @@
     version: '2.1.1',
     enabled: 'ontouchstart' in document.documentElement,
     preventDefault: true,
-    threshold: 20
+    threshold: 20,
+    ignoreMultiTouch: false
   };
 
   var startX,
@@ -51,6 +52,11 @@
       isMoving = true;
       this.addEventListener('touchmove', onTouchMove, false);
       this.addEventListener('touchend', onTouchEnd, false);
+    }
+    else if ($.detectSwipe.ignoreMultiTouch) {
+      // Ignore move & end events if more than one touch
+      this.removeEventListener('touchmove', onTouchMove);
+      this.removeEventListener('touchend', onTouchEnd); 
     }
   }
 


### PR DESCRIPTION
For a project I'm using this on, I don't want the swipe events being triggered for multi-touch scenarios (ie. pinch zoom) so I added the `ignoreMultiTouch` option.  If you think it would be useful to others, you can merge.