### PR TITLE
Forgotten teardown

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+    <title>Example use of Detect Swipe</title>
+    <main>
+        <h1>Example use of Detect Swipe</h1>
+        <p>Swipe over next gray area</p>
+        <div id="playground"></div>
+        <pre id="console">Log:</pre>
+    </main>
+    <style>
+        h1, p {
+            text-align: center;
+            font-family: sans-serif;
+        }
+        #playground {
+            background: gray;
+            width: 200px;
+            height: 200px;
+            margin: 30px auto;
+        }
+        #console {
+            background: #333333;
+            color: #cccccc;
+            display: block;
+            margin: 0 auto 30px;
+        }
+    </style>
+    <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script src="./jquery.detect_swipe.js"></script>
+    <script>
+        var $console = $('#console');
+        function log(text) {
+            $console.append('\n' + text);
+        }
+        $('#playground')
+        .on('swipe', function(e, dir) {
+            log('swipe     dir=' + dir);
+        })
+        .on('swipeleft', function() {
+            log('swipeleft');
+        })
+        .on('swiperight', function() {
+            log('swiperight');
+        })
+        .on('swipeup', function() {
+            log('swipeup');
+        })
+        .on('swipedown', function() {
+            log('swipedown');
+        });
+    </script>
+</html>

--- a/example.html
+++ b/example.html
@@ -3,8 +3,7 @@
     <title>Example use of Detect Swipe</title>
     <main>
         <h1>Example use of Detect Swipe</h1>
-        <p>Swipe over next gray area</p>
-        <div id="playground"></div>
+        <p>Use buttons to enable handlers and swipe over next gray area</p>
         <div id="toolbar">
             <button type="button" id="toggleSwipe"></button>
             <button type="button" id="toggleLeft"></button>
@@ -12,6 +11,7 @@
             <button type="button" id="toggleUp"></button>
             <button type="button" id="toggleDown"></button>
         </div>
+        <div id="playground"></div>
         <pre id="console">Log:</pre>
     </main>
     <style>

--- a/example.html
+++ b/example.html
@@ -5,6 +5,13 @@
         <h1>Example use of Detect Swipe</h1>
         <p>Swipe over next gray area</p>
         <div id="playground"></div>
+        <div id="toolbar">
+            <button type="button" id="toggleSwipe"></button>
+            <button type="button" id="toggleLeft"></button>
+            <button type="button" id="toggleRight"></button>
+            <button type="button" id="toggleUp"></button>
+            <button type="button" id="toggleDown"></button>
+        </div>
         <pre id="console">Log:</pre>
     </main>
     <style>
@@ -17,6 +24,10 @@
             width: 200px;
             height: 200px;
             margin: 30px auto;
+        }
+        #toolbar {
+            text-align: center;
+            margin: 0 15px 20px;
         }
         #console {
             background: #333333;
@@ -32,21 +43,64 @@
         function log(text) {
             $console.append('\n' + text);
         }
-        $('#playground')
-        .on('swipe', function(e, dir) {
-            log('swipe     dir=' + dir);
-        })
-        .on('swipeleft', function() {
-            log('swipeleft');
-        })
-        .on('swiperight', function() {
-            log('swiperight');
-        })
-        .on('swipeup', function() {
-            log('swipeup');
-        })
-        .on('swipedown', function() {
-            log('swipedown');
+        var $playground = $('#playground');
+
+        var BUTTON_ENABLE = 'Enable ';
+        var BUTTON_DISABLE = 'Disable ';
+        /**
+         * Definitions and state of buttons
+         */
+        var buttons = [
+            {
+                id: 'toggleSwipe',
+                name: 'swipe',
+                label: 'swipe (any direction)',
+                enabled: false,
+                message: 'swipe     dir='
+            }, {
+                id: 'toggleLeft',
+                name: 'swipeleft',
+                enabled: false
+            }, {
+                id: 'toggleRight',
+                name: 'swiperight',
+                enabled: false
+            }, {
+                id: 'toggleUp',
+                name: 'swipeup',
+                enabled: false
+            }, {
+                id: 'toggleDown',
+                name: 'swipedown',
+                enabled: false
+            }
+        ];
+        var setLabel = function($button, button) {
+            if (button.enabled) {
+                $button.text(BUTTON_DISABLE + (button.label || button.name));
+            }
+            else {
+                $button.text(BUTTON_ENABLE + (button.label || button.name));
+            }
+        }
+        buttons.forEach(function(button) {
+            var $btn = $('#' + button.id);
+            // Initial label
+            setLabel($btn, button);
+            // Click handler to enable/disable swipes
+            $btn.on('click', function() {
+                if (button.enabled) {
+                    $playground.off(button.name + '.toggleButton');
+                }
+                else {
+                    $playground.on(button.name + '.toggleButton', function(e, dir) {
+                        var msg = button.message ? (button.message + (dir || '')) : button.name;
+                        log(msg);
+                    });
+                }
+                button.enabled = !button.enabled;
+                setLabel($btn, button);
+            });
         });
     </script>
 </html>

--- a/jquery.detect_swipe.js
+++ b/jquery.detect_swipe.js
@@ -72,10 +72,10 @@
   }
 
   function teardown() {
-    this.removeEventListener('touchstart', onTouchStart);
+    this.removeEventListener && this.removeEventListener('touchstart', onTouchStart);
   }
 
-  $.event.special.swipe = { setup: setup };
+  $.event.special.swipe = { setup: setup, teardown: teardown };
 
   $.each(['left', 'up', 'down', 'right'], function () {
     $.event.special['swipe' + this] = { setup: function(){

--- a/jquery.detect_swipe.js
+++ b/jquery.detect_swipe.js
@@ -80,10 +80,14 @@
   $.each(['left', 'up', 'down', 'right'], function (i, name) {
     $.event.special['swipe' + this] = {
       setup: function(){
-          $(this).on('swipe.internal' + name, $.noop);
+        // DEBUG: To try that 'teardown' and namespacing is working as expected,
+        // replace next `$.noop` by a `function(){ console.log('__debugging swipe__');}`
+        // and use example.html enabling swipeleft and disabling (events will
+        // continue to log the debug messages at console)
+        $(this).on('swipe.internal' + name, $.noop);
       },
       teardown: function() {
-          $(this).off('swipe.internal' + name);
+        $(this).off('swipe.internal' + name);
       }
   };
   });

--- a/jquery.detect_swipe.js
+++ b/jquery.detect_swipe.js
@@ -77,9 +77,14 @@
 
   $.event.special.swipe = { setup: setup, teardown: teardown };
 
-  $.each(['left', 'up', 'down', 'right'], function () {
-    $.event.special['swipe' + this] = { setup: function(){
-      $(this).on('swipe', $.noop);
-    } };
+  $.each(['left', 'up', 'down', 'right'], function (i, name) {
+    $.event.special['swipe' + this] = {
+      setup: function(){
+          $(this).on('swipe.internal' + name, $.noop);
+      },
+      teardown: function() {
+          $(this).off('swipe.internal' + name);
+      }
+  };
   });
 }));


### PR DESCRIPTION
The plugin had a `teardown` function defined but never used. I connected it to the set-up of `swipe` event.
The direction-specific events needed a different teardown, so I implemented that.

Additionally, I added an `example.html` file to try the plugin in a simple page. It helps to check that events are behaving as expected after changes and too the teardown (I left a comment in the teardown code about how to test the bug generated by the lack of this with the previous code).

PS: Thanks for this plugin!